### PR TITLE
Fix footer rendering

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "printWidth": 100,
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "arrowParens": "avoid"
+}

--- a/packages/site/components/Layout.tsx
+++ b/packages/site/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { BuilderComponent, BuilderContent } from '@builder.io/react';
+import { BuilderComponent } from '@builder.io/react';
 import Head from 'next/head';
 import React, { ReactNode } from 'react';
 import { LayoutContext } from '../context/layout';

--- a/packages/site/components/Layout.tsx
+++ b/packages/site/components/Layout.tsx
@@ -1,8 +1,8 @@
-import React, { ReactNode } from "react";
-import builder, { BuilderComponent, BuilderContent } from "@builder.io/react";
-import { GetStaticProps } from "next";
-import Head from "next/head";
-import Navigation from "./Navigation";
+import { BuilderComponent, BuilderContent } from '@builder.io/react';
+import Head from 'next/head';
+import React, { ReactNode } from 'react';
+import { LayoutContext } from '../context/layout';
+import Navigation from './Navigation';
 
 type Props = {
   children?: ReactNode;
@@ -10,16 +10,14 @@ type Props = {
   ogImage?: string;
   description?: string;
   hideHeaderAndFooter?: boolean;
-  footerContent?: BuilderContent;
 };
 
 const Layout = ({
   children,
-  title = "HeadlessApp.Store | Blazing fast ecommerce integrations",
-  ogImage = "https://headlessapp.store/assets/new-one.png",
-  description = "Request early access now",
+  title = 'HeadlessApp.Store | Blazing fast ecommerce integrations',
+  ogImage = 'https://headlessapp.store/assets/new-one.png',
+  description = 'Request early access now',
   hideHeaderAndFooter = false,
-  footerContent
 }: Props) => (
   <div>
     <Head>
@@ -41,23 +39,15 @@ const Layout = ({
     )}
     {children}
     {!hideHeaderAndFooter && (
-      <footer className="p-16 text-center">
-        <BuilderComponent content={footerContent} model="footer" />
-      </footer>
+      <LayoutContext.Consumer>
+        {({ footerContent }) => (
+          <footer className="p-16 text-center">
+            <BuilderComponent content={footerContent} model="footer" />
+          </footer>
+        )}
+      </LayoutContext.Consumer>
     )}
   </div>
 );
-
-export const getStaticProps: GetStaticProps = async (context: any) => {
-  const footerContent: BuilderContent = await builder
-    .get("footer", { url: context.resolvedUrl })
-    .promise();
-
-  return {
-    props: { footerContent },
-    revalidate: true,
-    notFound: !footerContent
-  };
-};
 
 export default Layout;

--- a/packages/site/context/layout.ts
+++ b/packages/site/context/layout.ts
@@ -1,0 +1,12 @@
+import type { BuilderContent } from '@builder.io/react';
+import { createContext } from 'react';
+
+const value = {
+  /**
+   * Content for the layout's footer.
+   * Undefined is used so that it's compatible with `BuilderComponent`
+   */
+  footerContent: undefined as BuilderContent | undefined,
+};
+
+export const LayoutContext = createContext(value);

--- a/packages/site/pages/_app.tsx
+++ b/packages/site/pages/_app.tsx
@@ -5,7 +5,6 @@ import type { AppContext, AppProps } from 'next/app';
 import App from 'next/app';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
-import { createContext } from 'react';
 import { LayoutContext } from '../context/layout';
 import '../styles/index.css';
 

--- a/packages/site/pages/_app.tsx
+++ b/packages/site/pages/_app.tsx
@@ -1,35 +1,37 @@
-import builder, { Builder } from "@builder.io/react";
-import type { AppProps } from "next/app";
-import dynamic from "next/dynamic";
-import Head from "next/head";
-import { tabsConfig } from "@builder.io/widgets/dist/lib/components/Tabs.config";
-import { accordionConfig } from "@builder.io/widgets/dist/lib/components/Accordion.config";
+import builder, { Builder, BuilderContent } from '@builder.io/react';
+import { accordionConfig } from '@builder.io/widgets/dist/lib/components/Accordion.config';
+import { tabsConfig } from '@builder.io/widgets/dist/lib/components/Tabs.config';
+import type { AppContext, AppProps } from 'next/app';
+import App from 'next/app';
+import dynamic from 'next/dynamic';
+import Head from 'next/head';
+import { createContext } from 'react';
+import { LayoutContext } from '../context/layout';
+import '../styles/index.css';
 
 Builder.registerComponent(
   dynamic(() =>
-    import("@builder.io/widgets/dist/lib/components/Tabs").then(
-      (mod) => mod.TabsComponent
-    )
+    import('@builder.io/widgets/dist/lib/components/Tabs').then(mod => mod.TabsComponent)
   ),
   tabsConfig
 );
 
 Builder.registerComponent(
   dynamic(() =>
-    import("@builder.io/widgets/dist/lib/components/Accordion").then(
-      (mod) => mod.AccordionComponent
-    )
+    import('@builder.io/widgets/dist/lib/components/Accordion').then(mod => mod.AccordionComponent)
   ),
   accordionConfig
 );
 
 Error.stackTraceLimit = 1000;
 
-import "../styles/index.css";
+builder.init('c33bcd23c29e45789677ba9aaaa7ce1d');
 
-builder.init("c33bcd23c29e45789677ba9aaaa7ce1d");
+type Resolved<PromiseT> = PromiseT extends PromiseLike<infer T> ? T : never;
+type MyAppInitialProps = Resolved<ReturnType<typeof MyApp.getInitialProps>>;
+type MyAppProps = AppProps & MyAppInitialProps;
 
-function MyApp({ Component, pageProps }: AppProps) {
+function MyApp({ Component, pageProps, layoutProps }: MyAppProps) {
   return (
     <>
       {/* <DefaultSeo {...SEO} /> */}
@@ -38,9 +40,21 @@ function MyApp({ Component, pageProps }: AppProps) {
         <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
       </Head>
 
-      <Component {...pageProps} />
+      <LayoutContext.Provider value={layoutProps}>
+        <Component {...pageProps} />
+      </LayoutContext.Provider>
     </>
   );
 }
+
+MyApp.getInitialProps = async (appCtx: AppContext) => {
+  const appProps = await App.getInitialProps(appCtx);
+
+  const footerContent: BuilderContent = await builder.get('footer', { url: appCtx.ctx.asPath }).promise();
+
+  const layoutProps = { footerContent };
+
+  return { ...appProps, layoutProps };
+};
 
 export default MyApp;

--- a/packages/site/pages/_document.tsx
+++ b/packages/site/pages/_document.tsx
@@ -1,9 +1,15 @@
-import Document, { Html, Head, Main, NextScript } from "next/document";
+import Document, {
+  Html,
+  Head,
+  Main,
+  NextScript,
+  DocumentContext,
+} from 'next/document'
 
 class MyDocument extends Document {
-  static async getInitialProps(ctx: any) {
-    const initialProps = await Document.getInitialProps(ctx);
-    return { ...initialProps };
+  static async getInitialProps(ctx: DocumentContext) {
+    const initialProps = await Document.getInitialProps(ctx)
+    return { ...initialProps }
   }
 
   render() {
@@ -17,8 +23,8 @@ class MyDocument extends Document {
           <NextScript />
         </body>
       </Html>
-    );
+    )
   }
 }
 
-export default MyDocument;
+export default MyDocument


### PR DESCRIPTION
- Format file
- Add Prettier config
- Add layout context

Adds a layout context to fix rendering the footer content.
I had tried to get the footer content using the static generation stuff before
but, as it happens this doesn't work in non-pages.

This PR modifies the app's getInitialProps call to fetch the footer content,
sets the value to a context, and used that context in the Layout component to
render the footer.
