### PR TITLE
ENG 1067 has rich text

### DIFF
--- a/packages/site/pages/_app.tsx
+++ b/packages/site/pages/_app.tsx
@@ -6,6 +6,8 @@ import App from 'next/app';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import { LayoutContext } from '../context/layout';
+
+import '../styles/tailwind.css';
 import '../styles/index.css';
 
 Builder.registerComponent(

--- a/packages/site/postcss.config.js
+++ b/packages/site/postcss.config.js
@@ -1,3 +1,14 @@
 module.exports = {
-  plugins: ["tailwindcss", "postcss-preset-env"],
-};
+  plugins: [
+    'tailwindcss',
+    [
+      'postcss-preset-env',
+      {
+        state: 2,
+        features: {
+          'nesting-rules': true,
+        },
+      },
+    ],
+  ],
+}

--- a/packages/site/styles/index.css
+++ b/packages/site/styles/index.css
@@ -1,7 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 .full-width {
   width: 100vw;
   position: relative;

--- a/packages/site/styles/index.css
+++ b/packages/site/styles/index.css
@@ -10,3 +10,54 @@
 .text-link {
   @apply text-primary;
 }
+
+/* Rich editor reset */
+.builder-text {
+  /* Lists */
+  & ol,
+  & ul {
+    @apply list-disc;
+    @apply list-inside;
+
+    padding-left: 2rem;
+  }
+
+  /* Links */
+  & a {
+    @apply text-primary;
+  }
+
+  /* Headers */
+  & h1 {
+    @apply text-4xl;
+  }
+
+  & h2 {
+    @apply text-3xl;
+  }
+
+  & h3 {
+    @apply text-2xl;
+  }
+
+  & h4 {
+    @apply text-xl;
+  }
+
+  & h5 {
+    @apply text-lg;
+  }
+
+  & h6 {
+    @apply text-base;
+  }
+
+  & h1,
+  & h2,
+  & h3,
+  & h4,
+  & h5,
+  & h6 {
+    font-weight: bold;
+  }
+}

--- a/packages/site/styles/tailwind.css
+++ b/packages/site/styles/tailwind.css
@@ -1,0 +1,4 @@
+@tailwind base;
+
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
Closes ENG-1067

This isn't intended to be perfect, but it restores most of the rich text formatting capabilities.

Another option would be to disable [tailwind's preflight](https://tailwindcss.com/docs/preflight)

- Tweak postcss config to support nesting
- Put tailwind directives in their own file
- Add default element styling for rich text content

![image](https://user-images.githubusercontent.com/3162299/111693441-03830980-8807-11eb-9b0d-6379664cd777.png)
